### PR TITLE
Add Vercel Analytics component to root layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -55,6 +55,7 @@ import { UTMTracker } from "@/components/UTMTracker";
 import PageViewTracker from "@/components/PageViewTracker";
 import { CookieBanner } from "@/components/CookieBanner";
 import { SpeedInsights } from '@vercel/speed-insights/next';
+import { Analytics } from '@vercel/analytics/react';
 
 export default function RootLayout({
   children,
@@ -140,6 +141,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </CartProvider>
         </CurrencyProvider>
         <SpeedInsights />
+        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
Adds the Analytics component from @vercel/analytics/react to enable comprehensive web analytics tracking across the entire site.

Changes:
- Import Analytics component in app/layout.tsx
- Add Analytics component to body alongside SpeedInsights
- Completes Vercel tracking setup (Speed Insights + Web Analytics)

The useAnalytics hook was already configured to use Vercel's track() function for custom events (checkout, purchase, button clicks, etc). With this change, all tracking events will now flow to the Vercel Analytics dashboard.

Key tracked events:
- Page views (automatic)
- Purchases (with funnel type, order bumps, product details)
- Checkout initiations
- Button clicks (location, type, product context)
- Upsell interactions (accept/decline)
- Social clicks, FAQ expansions, story clicks