### PR TITLE
Add Black Friday pricing banner to page

### DIFF
--- a/app/6wcv2/page.tsx
+++ b/app/6wcv2/page.tsx
@@ -288,31 +288,13 @@ export default function BlackFridayChallengePage() {
           {[...Array(3)].map((_, i) => (
             <span key={i} className="inline-block">
               <span className="mx-8 font-bold text-sm sm:text-base">
-                Normally $197
-              </span>
-              <span className="mx-8 font-bold text-sm sm:text-base">
-                •
-              </span>
-              <span className="mx-8 font-bold text-sm sm:text-base">
                 50% off for Black Friday
               </span>
               <span className="mx-8 font-bold text-sm sm:text-base">
                 •
               </span>
               <span className="mx-8 font-bold text-sm sm:text-base">
-                Now just $97
-              </span>
-              <span className="mx-8 font-bold text-sm sm:text-base">
-                •
-              </span>
-              <span className="mx-8 font-bold text-sm sm:text-base">
                 Only {spotsRemaining} spots remaining
-              </span>
-              <span className="mx-8 font-bold text-sm sm:text-base">
-                •
-              </span>
-              <span className="mx-8 font-bold text-sm sm:text-base">
-                Act fast!
               </span>
               <span className="mx-8 font-bold text-sm sm:text-base">
                 •


### PR DESCRIPTION
Updated the sticky banner on 6wcv2 page to display only:
- 50% off for Black Friday
- Only X spots remaining
- Get lifetime access to all course content with the VIP

Removed pricing details and "Act fast!" for a cleaner, more focused message.