### PR TITLE
Fix BFC success URL to redirect to /success/6wc

### DIFF
--- a/lib/stripe/checkout.ts
+++ b/lib/stripe/checkout.ts
@@ -268,15 +268,15 @@ export async function createCheckoutSession({
     funnelType = 'merch'
     successPath = '/success/merch'
   } else if (has6WC) {
-    // 6WC uses membership success page (same as BFC - shows coaching upsell)
+    // 6WC uses 6wc success page
     funnelType = '6wc'
-    successPath = '/success/membership'
+    successPath = '/success/6wc'
   } else if (hasBFC) {
     funnelType = 'bfc'
-    successPath = '/success/membership' // BFC uses membership success (coaching upsell)
+    successPath = '/success/6wc' // BFC uses 6wc success page
   } else if (hasBFCVIP) {
     funnelType = 'bfc-vip'
-    successPath = '/success/membership' // BFC VIP uses membership success (coaching upsell)
+    successPath = '/success/6wc' // BFC VIP uses 6wc success page
   } else if (mainProduct?.id === 'bundle') {
     funnelType = 'bundle'
     successPath = '/success/course' // Bundle uses course success


### PR DESCRIPTION
- Update Black Friday Challenge (BFC) success page routing
- Change BFC standard and VIP success URLs from /success/membership to /success/6wc
- Also update 6WC success URL to use /success/6wc (was incorrectly using /success/membership)
- This prevents BFC purchasers from seeing membership-specific onboarding call bookings

All BFC purchases (standard, VIP, and 6WC) now correctly redirect to /success/6wc
after successful payment.